### PR TITLE
Add support for keybuf to boot2

### DIFF
--- a/sys/boot/geli/geliboot.c
+++ b/sys/boot/geli/geliboot.c
@@ -27,53 +27,75 @@
  * $FreeBSD$
  */
 
-#include <crypto/intake.h>
-
+#include "geliboot_internal.h"
 #include "geliboot.h"
 
 SLIST_HEAD(geli_list, geli_entry) geli_head = SLIST_HEAD_INITIALIZER(geli_head);
 struct geli_list *geli_headp;
 
-typedef u_char geli_mkey[G_ELI_DATAIVKEYLEN];
+typedef u_char geli_ukey[G_ELI_USERKEYLEN];
 
-static geli_mkey saved_keys[GELI_MAX_KEYS];
+static geli_ukey saved_keys[GELI_MAX_KEYS];
 static unsigned int nsaved_keys = 0;
 
+/*
+ * Copy keys from local storage to the keybuf struct.
+ * Destroy the local storage when finished.
+ */
 void
-geli_fill_keybuf(struct keybuf *keybuf)
+geli_fill_keybuf(struct keybuf *fkeybuf)
 {
-        unsigned int i;
+	unsigned int i;
 
-        for (i = 0; i < nsaved_keys; i++) {
-                keybuf->kb_ents[i].ke_type = KEYBUF_TYPE_GELI;
-                memcpy(keybuf->kb_ents[i].ke_data, saved_keys[i],
-                    G_ELI_DATAIVKEYLEN);
-        }
+	for (i = 0; i < nsaved_keys; i++) {
+		fkeybuf->kb_ents[i].ke_type = KEYBUF_TYPE_GELI;
+		memcpy(fkeybuf->kb_ents[i].ke_data, saved_keys[i],
+		    G_ELI_USERKEYLEN);
+	}
+	fkeybuf->kb_nents = nsaved_keys;
+	bzero(saved_keys, sizeof(saved_keys));
+}
 
-        keybuf->kb_nents = nsaved_keys;
-        bzero(saved_keys, sizeof(saved_keys));
+/*
+ * Copy keys from a keybuf struct into local storage.
+ * Zero out the keybuf.
+ */
+void
+geli_save_keybuf(struct keybuf *skeybuf)
+{
+	unsigned int i;
+
+	for (i = 0; i < skeybuf->kb_nents && i < GELI_MAX_KEYS; i++) {
+		memcpy(saved_keys[i], skeybuf->kb_ents[i].ke_data,
+		    G_ELI_USERKEYLEN);
+		bzero(skeybuf->kb_ents[i].ke_data,
+		    G_ELI_USERKEYLEN);
+		skeybuf->kb_ents[i].ke_type = KEYBUF_TYPE_NONE;
+	}
+	nsaved_keys = skeybuf->kb_nents;
+	skeybuf->kb_nents = 0;
 }
 
 static void
-save_key(geli_mkey key)
+save_key(geli_ukey key)
 {
 
-        /*
-         * If we run out of key space, the worst that will happen is
-         * it will ask the user for the password again.
-         */
-        if (nsaved_keys < GELI_MAX_KEYS) {
-                memcpy(saved_keys[nsaved_keys], key, G_ELI_DATAIVKEYLEN);
-                nsaved_keys++;
-        }
+	/*
+	 * If we run out of key space, the worst that will happen is
+	 * it will ask the user for the password again.
+	 */
+	if (nsaved_keys < GELI_MAX_KEYS) {
+		memcpy(saved_keys[nsaved_keys], key, G_ELI_USERKEYLEN);
+		nsaved_keys++;
+	}
 }
 
 static int
 geli_same_device(struct geli_entry *ge, struct dsk *dskp)
 {
 
-	if (geli_e->dsk->drive == dskp->drive &&
-	    dskp->part == 255 && geli_e->dsk->part == dskp->slice) {
+	if (ge->dsk->drive == dskp->drive &&
+	    dskp->part == 255 && ge->dsk->part == dskp->slice) {
 		/*
 		 * Sometimes slice = slice, and sometimes part = slice
 		 * If the incoming struct dsk has part=255, it means look at
@@ -83,13 +105,37 @@ geli_same_device(struct geli_entry *ge, struct dsk *dskp)
 	}
 
 	/* Is this the same device? */
-	if (geli_e->dsk->drive != dskp->drive ||
-	    geli_e->dsk->slice != dskp->slice ||
-	    geli_e->dsk->part != dskp->part) {
+	if (ge->dsk->drive != dskp->drive ||
+	    ge->dsk->slice != dskp->slice ||
+	    ge->dsk->part != dskp->part) {
 		return (1);
 	}
 
 	return (0);
+}
+
+static int
+geli_findkey(struct geli_entry *ge, struct dsk *dskp, u_char *mkey)
+{
+	u_int keynum;
+	int i;
+
+	if (ge->keybuf_slot >= 0) {
+		if (g_eli_mkey_decrypt(&ge->md, saved_keys[ge->keybuf_slot],
+		    mkey, &keynum) == 0) {
+			return (0);
+		}
+	}
+
+	for (i = 0; i < nsaved_keys; i++) {
+		if (g_eli_mkey_decrypt(&ge->md, saved_keys[i], mkey,
+		    &keynum) == 0) {
+			ge->keybuf_slot = i;
+			return (0);
+		}
+	}
+
+	return (1);
 }
 
 void
@@ -159,6 +205,7 @@ geli_taste(int read_func(void *vdev, void *priv, off_t off, void *buf,
 	if (dskp->part == 255) {
 		geli_e->dsk->part = dskp->slice;
 	}
+	geli_e->keybuf_slot = -1;
 
 	geli_e->md = md;
 	eli_metadata_softc(&geli_e->sc, &md, DEV_BSIZE,
@@ -184,6 +231,10 @@ geli_attach(struct dsk *dskp, const char *passphrase)
 	SLIST_FOREACH_SAFE(geli_e, &geli_head, entries, geli_e_tmp) {
 		if (geli_same_device(geli_e, dskp) != 0) {
 			continue;
+		}
+
+		if (geli_findkey(geli_e, dskp, mkey) == 0) {
+			goto found_key;
 		}
 
 		g_eli_crypto_hmac_init(&ctx, NULL, 0);
@@ -217,20 +268,22 @@ geli_attach(struct dsk *dskp, const char *passphrase)
 		error = g_eli_mkey_decrypt(&geli_e->md, key, mkey, &keynum);
 		if (error == -1) {
 			bzero(&mkey, sizeof(mkey));
-                        bzero(&key, sizeof(key));
-			printf("Bad GELI key: %d\n", error);
+			bzero(&key, sizeof(key));
+			printf("Bad GELI key: bad password?\n");
 			return (error);
 		} else if (error != 0) {
 			bzero(&mkey, sizeof(mkey));
-                        bzero(&key, sizeof(key));
+			bzero(&key, sizeof(key));
                         printf("Failed to decrypt GELI master key: %d\n", error);
 			return (error);
 		} else {
-                        /* Store the keys */
+                        /* Add key to keychain */
                         save_key(key);
                         bzero(&key, sizeof(key));
                 }
 
+found_key:
+		/* Store the keys */
 		bcopy(mkey, geli_e->sc.sc_mkey, sizeof(geli_e->sc.sc_mkey));
 		bcopy(mkey, geli_e->sc.sc_ivkey, sizeof(geli_e->sc.sc_ivkey));
 		mkp = mkey + sizeof(geli_e->sc.sc_ivkey);
@@ -330,6 +383,28 @@ geli_read(struct dsk *dskp, off_t offset, u_char *buf, size_t bytes)
 	}
 
 	printf("GELI provider not found\n");
+	return (1);
+}
+
+int
+geli_havekey(struct dsk *dskp)
+{
+	u_char mkey[G_ELI_DATAIVKEYLEN];
+
+	SLIST_FOREACH_SAFE(geli_e, &geli_head, entries, geli_e_tmp) {
+		if (geli_same_device(geli_e, dskp) != 0) {
+			continue;
+		}
+
+		if (geli_findkey(geli_e, dskp, mkey) == 0) {
+			bzero(mkey, sizeof(mkey));
+			if (geli_attach(dskp, NULL) == 0) {
+				return (0);
+			}
+		}
+	}
+	bzero(mkey, sizeof(mkey));
+
 	return (1);
 }
 

--- a/sys/boot/geli/geliboot_crypto.c
+++ b/sys/boot/geli/geliboot_crypto.c
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <strings.h>
 
+#include "geliboot_internal.h"
 #include "geliboot.h"
 
 int

--- a/sys/boot/geli/geliboot_internal.h
+++ b/sys/boot/geli/geliboot_internal.h
@@ -27,42 +27,43 @@
  * $FreeBSD$
  */
 
-#include <crypto/intake.h>
+#ifndef _GELIBOOT_INTERNAL_H_
+#define _GELIBOOT_INTERNAL_H_
 
-#ifndef _GELIBOOT_H_
-#define _GELIBOOT_H_
+#define _STRING_H_
+#define _STRINGS_H_
+#define _STDIO_H_
 
-#ifndef DEV_BSIZE
-#define DEV_BSIZE 			512
-#endif
-#ifndef DEV_GELIBOOT_BSIZE
-#define DEV_GELIBOOT_BSIZE		4096
-#endif
+#include <sys/endian.h>
+#include <sys/queue.h>
 
-#ifndef MIN
-#define    MIN(a,b) (((a) < (b)) ? (a) : (b))
-#endif
+#include <geom/eli/g_eli.h>
+#include <geom/eli/pkcs5v2.h>
 
-#define	GELI_MAX_KEYS			64
-#define GELI_PW_MAXLEN			256
+#include <bootstrap.h>
 
-extern void pwgets(char *buf, int n);
+/* Pull in the md5, sha256, and sha512 implementations */
+#include <md5.h>
+#include <crypto/sha2/sha256.h>
+#include <crypto/sha2/sha512.h>
 
-void geli_init(void);
-int geli_taste(int read_func(void *vdev, void *priv, off_t off,
-    void *buf, size_t bytes), struct dsk *dsk, daddr_t lastsector);
-int geli_attach(struct dsk *dskp, const char *passphrase);
-int is_geli(struct dsk *dsk);
-int geli_read(struct dsk *dsk, off_t offset, u_char *buf, size_t bytes);
-int geli_decrypt(u_int algo, u_char *data, size_t datasize,
-    const u_char *key, size_t keysize, const uint8_t* iv);
-int geli_havekey(struct dsk *dskp);
-int geli_passphrase(char *pw, int disk, int parttype, int part, struct dsk *dskp);
+/* Pull in AES implementation */
+#include <crypto/rijndael/rijndael-api-fst.h>
 
-int geliboot_crypt(u_int algo, int enc, u_char *data, size_t datasize,
-    const u_char *key, size_t keysize, u_char *iv);
+/* AES-XTS implementation */
+#define _STAND
+#define STAND_H /* We don't want stand.h in {gpt,zfs,gptzfs}boot */
+#include <opencrypto/xform_enc.h>
 
-void geli_fill_keybuf(struct keybuf *keybuf);
-void geli_save_keybuf(struct keybuf *keybuf);
+struct geli_entry {
+	struct dsk		*dsk;
+	off_t			part_end;
+	struct g_eli_softc	sc;
+	struct g_eli_metadata	md;
+	int			keybuf_slot;
+	SLIST_ENTRY(geli_entry)	entries;
+} *geli_e, *geli_e_tmp;
 
-#endif /* _GELIBOOT_H_ */
+static int geli_count;
+
+#endif /* _GELIBOOT_INTERNAL_H_ */

--- a/sys/boot/i386/common/bootargs.h
+++ b/sys/boot/i386/common/bootargs.h
@@ -64,10 +64,28 @@ struct bootargs
 	 */
 };
 
+#ifdef LOADER_GELI_SUPPORT
+#include <crypto/intake.h>
+#endif
+
 struct geli_boot_args
 {
     uint32_t		size;
-    char		gelipw[256];
+    union {
+        char            gelipw[256];
+        struct {
+            char                notapw;	/* 
+					 * single null byte to stop keybuf
+					 * being interpreted as a password
+					 */
+            uint32_t            keybuf_sentinel;
+#ifdef LOADER_GELI_SUPPORT
+            struct keybuf       *keybuf;
+#else
+            void                *keybuf;
+#endif
+        };
+    };
 };
 
 #endif /*__ASSEMBLER__*/

--- a/sys/boot/i386/gptboot/Makefile
+++ b/sys/boot/i386/gptboot/Makefile
@@ -42,6 +42,7 @@ CFLAGS.gcc+=	--param max-inline-insns-single=100
 .if !defined(LOADER_NO_GELI_SUPPORT)
 CFLAGS+=	-DLOADER_GELI_SUPPORT
 CFLAGS+=	-I${.CURDIR}/../../geli
+CFLAGS+=	-I${.CURDIR}/../../..
 LIBGELIBOOT=	${.OBJDIR}/../../geli/libgeliboot.a
 .PATH:		${.CURDIR}/../../../opencrypto
 OPENCRYPTO_XTS=	xform_aes_xts.o

--- a/sys/boot/i386/gptboot/gptboot.c
+++ b/sys/boot/i386/gptboot/gptboot.c
@@ -137,6 +137,7 @@ free(void *ptr)
 #ifdef LOADER_GELI_SUPPORT
 #include "geliboot.c"
 static char gelipw[GELI_PW_MAXLEN];
+static struct keybuf *gelibuf;
 #endif
 
 static inline int
@@ -251,7 +252,8 @@ gptinit(void)
 #ifdef LOADER_GELI_SUPPORT
 	if (geli_taste(vdev_read, &dsk, (gpttable[curent].ent_lba_end -
 	    gpttable[curent].ent_lba_start)) == 0) {
-		if (geli_passphrase(&gelipw, dsk.unit, 'p', curent + 1, &dsk) != 0) {
+		if (geli_havekey(&dsk) != 0 && geli_passphrase(&gelipw,
+		    dsk.unit, 'p', curent + 1, &dsk) != 0) {
 			printf("%s: unable to decrypt GELI key\n", BOOTPROG);
 			return (-1);
 		}
@@ -478,10 +480,14 @@ load(void)
     bootinfo.bi_bios_dev = dsk.drive;
     geliargs.size = sizeof(geliargs);
 #ifdef LOADER_GELI_SUPPORT
-    bcopy(gelipw, geliargs.gelipw, sizeof(geliargs.gelipw));
     bzero(gelipw, sizeof(gelipw));
+    gelibuf = malloc(sizeof(struct keybuf) + (GELI_MAX_KEYS * sizeof(struct keybuf_ent)));
+    geli_fill_keybuf(gelibuf);
+    geliargs.notapw = '\0';
+    geliargs.keybuf_sentinel = KEYBUF_SENTINEL;
+    geliargs.keybuf = gelibuf;
 #else
-	geliargs.gelipw[0] = '\0';
+    geliargs.gelipw[0] = '\0';
 #endif
     __exec((caddr_t)addr, RB_BOOTINFO | (opts & RBX_MASK),
 	   MAKEBOOTDEV(dev_maj[dsk.type], dsk.part + 1, dsk.unit, 0xff),

--- a/sys/boot/i386/libi386/biosdisk.c
+++ b/sys/boot/i386/libi386/biosdisk.c
@@ -484,6 +484,11 @@ bd_open(struct open_file *f, ...)
 		}
 		if (geli_taste(bios_read, &dskp,
 		    entry->part.end - entry->part.start) == 0) {
+			if (geli_havekey(&dskp) == 0) {
+				geli_status[dev->d_unit][dskp.slice] = ISGELI_YES;
+				geli_part++;
+				continue;
+			}
 			if ((passphrase = getenv("kern.geom.eli.passphrase"))
 			    != NULL) {
 				/* Use the cached passphrase */
@@ -496,6 +501,7 @@ bd_open(struct open_file *f, ...)
 				bzero(gelipw, sizeof(gelipw));
 				geli_status[dev->d_unit][dskp.slice] = ISGELI_YES;
 				geli_part++;
+				continue;
 			}
 		} else
 			geli_status[dev->d_unit][dskp.slice] = ISGELI_NO;

--- a/sys/boot/i386/loader/Makefile
+++ b/sys/boot/i386/loader/Makefile
@@ -61,6 +61,7 @@ CFLAGS+=	-DLOADER_NANDFS_SUPPORT
 .endif
 .if !defined(LOADER_NO_GELI_SUPPORT)
 CFLAGS+=	-DLOADER_GELI_SUPPORT
+CFLAGS+=	-I${.CURDIR}/../../geli
 LIBGELIBOOT=	${.OBJDIR}/../../geli/libgeliboot.a
 .PATH:		${.CURDIR}/../../../opencrypto
 SRCS+=		xform_aes_xts.c

--- a/sys/boot/i386/loader/main.c
+++ b/sys/boot/i386/loader/main.c
@@ -39,6 +39,7 @@ __FBSDID("$FreeBSD$");
 #include <machine/cpufunc.h>
 #include <machine/psl.h>
 #include <sys/reboot.h>
+#include <common/drv.h>
 
 #include "bootstrap.h"
 #include "common/bootargs.h"
@@ -69,6 +70,7 @@ static int		isa_inb(int port);
 static void		isa_outb(int port, int value);
 void			exit(int code);
 #ifdef LOADER_GELI_SUPPORT
+#include "geliboot.h"
 struct geli_boot_args	*gargs;
 #endif
 #ifdef LOADER_ZFS_SUPPORT
@@ -177,6 +179,10 @@ main(void)
 		setenv("kern.geom.eli.passphrase", zargs->gelipw, 1);
 		bzero(zargs->gelipw, sizeof(zargs->gelipw));
 	    }
+	    if (zargs->keybuf_sentinel == KEYBUF_SENTINEL) {
+printf("LOADER: found keybuf sentinel\n");
+		geli_save_keybuf(zargs->keybuf);
+	    }
 	}
     }
 #endif /* LOADER_GELI_SUPPORT */
@@ -188,6 +194,9 @@ main(void)
 	    if (gargs->gelipw[0] != '\0') {
 		setenv("kern.geom.eli.passphrase", gargs->gelipw, 1);
 		bzero(gargs->gelipw, sizeof(gargs->gelipw));
+	    }
+	    if (gargs->keybuf_sentinel == KEYBUF_SENTINEL) {
+		geli_save_keybuf(gargs->keybuf);
 	    }
 	}
     }

--- a/sys/boot/i386/loader/main.c
+++ b/sys/boot/i386/loader/main.c
@@ -175,13 +175,12 @@ main(void)
     if ((kargs->bootflags & KARGS_FLAGS_EXTARG) != 0) {
 	zargs = (struct zfs_boot_args *)(kargs + 1);
 	if (zargs != NULL && zargs->size >= offsetof(struct zfs_boot_args, gelipw)) {
+	    if (zargs->keybuf_sentinel == KEYBUF_SENTINEL) {
+		geli_save_keybuf(zargs->keybuf);
+	    }
 	    if (zargs->gelipw[0] != '\0') {
 		setenv("kern.geom.eli.passphrase", zargs->gelipw, 1);
 		bzero(zargs->gelipw, sizeof(zargs->gelipw));
-	    }
-	    if (zargs->keybuf_sentinel == KEYBUF_SENTINEL) {
-printf("LOADER: found keybuf sentinel\n");
-		geli_save_keybuf(zargs->keybuf);
 	    }
 	}
     }
@@ -191,12 +190,12 @@ printf("LOADER: found keybuf sentinel\n");
     if ((kargs->bootflags & KARGS_FLAGS_EXTARG) != 0) {
 	gargs = (struct geli_boot_args *)(kargs + 1);
 	if (gargs != NULL && gargs->size >= offsetof(struct geli_boot_args, gelipw)) {
+	    if (gargs->keybuf_sentinel == KEYBUF_SENTINEL) {
+		geli_save_keybuf(gargs->keybuf);
+	    }
 	    if (gargs->gelipw[0] != '\0') {
 		setenv("kern.geom.eli.passphrase", gargs->gelipw, 1);
 		bzero(gargs->gelipw, sizeof(gargs->gelipw));
-	    }
-	    if (gargs->keybuf_sentinel == KEYBUF_SENTINEL) {
-		geli_save_keybuf(gargs->keybuf);
 	    }
 	}
     }

--- a/sys/boot/i386/zfsboot/zfsboot.c
+++ b/sys/boot/i386/zfsboot/zfsboot.c
@@ -159,6 +159,7 @@ strdup(const char *s)
 #ifdef LOADER_GELI_SUPPORT
 #include "geliboot.c"
 static char gelipw[GELI_PW_MAXLEN];
+static struct keybuf *gelibuf;
 #endif
 
 #include "zfsimpl.c"
@@ -502,7 +503,8 @@ probe_drive(struct dsk *dsk)
 	elba--;
     }
     if (geli_taste(vdev_read, dsk, elba) == 0) {
-	if (geli_passphrase(&gelipw, dsk->unit, ':', 0, dsk) == 0) {
+	if (geli_havekey(dsk) == 0 || geli_passphrase(&gelipw, dsk->unit,
+	  ':', 0, dsk) == 0) {
 	    if (vdev_probe(vdev_read, dsk, NULL) == 0) {
 		return;
 	    }
@@ -559,7 +561,8 @@ probe_drive(struct dsk *dsk)
 #ifdef LOADER_GELI_SUPPORT
 		else if (geli_taste(vdev_read, dsk, ent->ent_lba_end -
 			 ent->ent_lba_start) == 0) {
-		    if (geli_passphrase(&gelipw, dsk->unit, 'p', dsk->slice, dsk) == 0) {
+		    if (geli_havekey(dsk) == 0 || geli_passphrase(&gelipw,
+		      dsk->unit, 'p', dsk->slice, dsk) == 0) {
 			/*
 			 * This slice has GELI, check it for ZFS.
 			 */
@@ -597,7 +600,8 @@ trymbr:
 #ifdef LOADER_GELI_SUPPORT
 	else if (geli_taste(vdev_read, dsk, dp[i].dp_size -
 		 dp[i].dp_start) == 0) {
-	    if (geli_passphrase(&gelipw, dsk->unit, 's', i, dsk) == 0) {
+	    if (geli_havekey(dsk) == 0 || geli_passphrase(&gelipw, dsk->unit,
+	      's', i, dsk) == 0) {
 		/*
 		 * This slice has GELI, check it for ZFS.
 		 */
@@ -925,8 +929,12 @@ load(void)
     zfsargs.root = zfsmount.rootobj;
     zfsargs.primary_pool = primary_spa->spa_guid;
 #ifdef LOADER_GELI_SUPPORT
-    bcopy(gelipw, zfsargs.gelipw, sizeof(zfsargs.gelipw));
     bzero(gelipw, sizeof(gelipw));
+    gelibuf = malloc(sizeof(struct keybuf) + (GELI_MAX_KEYS * sizeof(struct keybuf_ent)));
+    geli_fill_keybuf(gelibuf);
+    zfsargs.notapw = '\0';
+    zfsargs.keybuf_sentinel = KEYBUF_SENTINEL;
+    zfsargs.keybuf = gelibuf;
 #else
     zfsargs.gelipw[0] = '\0';
 #endif

--- a/sys/boot/zfs/libzfs.h
+++ b/sys/boot/zfs/libzfs.h
@@ -47,6 +47,10 @@ struct zfs_devdesc
     uint64_t		root_guid;
 };
 
+#ifdef LOADER_GELI_SUPPORT
+#include <crypto/intake.h>
+#endif
+
 struct zfs_boot_args
 {
     uint32_t		size;
@@ -55,7 +59,21 @@ struct zfs_boot_args
     uint64_t		root;
     uint64_t		primary_pool;
     uint64_t		primary_vdev;
-    char		gelipw[256];
+    union {
+	char		gelipw[256];
+	struct {
+            char                notapw;	/* 
+					 * single null byte to stop keybuf
+					 * being interpreted as a password
+					 */
+	    uint32_t		keybuf_sentinel;
+#ifdef LOADER_GELI_SUPPORT
+	    struct keybuf	*keybuf;
+#else
+	    void		*keybuf;
+#endif
+	};
+    };
 };
 
 int	zfs_parsedev(struct zfs_devdesc *dev, const char *devspec,

--- a/sys/crypto/intake.h
+++ b/sys/crypto/intake.h
@@ -39,6 +39,8 @@
 #define MAX_KEY_BITS	4096
 #define	MAX_KEY_BYTES	(MAX_KEY_BITS / NBBY)
 
+#define KEYBUF_SENTINEL	0xcee54b5d	/* KEYS4BSD */
+
 enum {
         KEYBUF_TYPE_NONE,
         KEYBUF_TYPE_GELI


### PR DESCRIPTION
Keys are passed from boot2 to loader using the new keybuf system
This saves re-calculating the key and speeds boot by a few seconds per disk

Also break the geliboot header into internal and external bits